### PR TITLE
Fix repository url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "keywords": [
         "signalk-node-server-plugin"
     ],
-    "repository": "https://github.com/panaaj/signalk-icons",
+    "repository": "https://github.com/panaaj/signalk-flags",
     "author": "AdrianP",
     "contributors": [
         {


### PR DESCRIPTION
I tried to click through from the npm page and got a 404.